### PR TITLE
Extender is now uses a key of mysql2 for compatibility with mysql2 gem for Rails 3. Closes GH-42

### DIFF
--- a/config/mysql_config.rb
+++ b/config/mysql_config.rb
@@ -3,7 +3,7 @@
 
 RR::Initializer::run do |config|
   config.left = {
-    :adapter  => 'mysql',   
+    :adapter  => 'mysql2',   
     :database => 'rr_left',   
     :username => 'root',   
     :password => '',   
@@ -13,7 +13,7 @@ RR::Initializer::run do |config|
   }
 
   config.right = {
-    :adapter  => 'mysql',   
+    :adapter  => 'mysql2',   
     :database => 'rr_right',   
     :username => 'root',   
     :password => '',   

--- a/lib/rubyrep/connection_extenders/mysql_extender.rb
+++ b/lib/rubyrep/connection_extenders/mysql_extender.rb
@@ -4,7 +4,7 @@ module RR
 
     # Provides various MySQL specific functionality required by Rubyrep.
     module MysqlExtender
-      RR::ConnectionExtenders.register :mysql => self
+      RR::ConnectionExtenders.register :mysql2 => self
 
       # Returns an ordered list of primary key column names of the given table
       def primary_key_names(table)

--- a/lib/rubyrep/generate_runner.rb
+++ b/lib/rubyrep/generate_runner.rb
@@ -9,7 +9,7 @@ module RR
     CONFIG_TEMPLATE = <<EOF
 RR::Initializer::run do |config|
   config.left = {
-    :adapter  => 'postgresql', # or 'mysql'
+    :adapter  => 'postgresql', # or 'mysql2'
     :database => 'SCOTT',
     :username => 'scott',
     :password => 'tiger',

--- a/lib/rubyrep/replication_extenders/mysql_replication.rb
+++ b/lib/rubyrep/replication_extenders/mysql_replication.rb
@@ -3,7 +3,7 @@ module RR
 
     # Provides Mysql specific functionality for database replication
     module MysqlReplication
-      RR::ReplicationExtenders.register :mysql => self
+      RR::ReplicationExtenders.register :mysql2 => self
 
       # Creates or replaces the replication trigger function.
       # See #create_replication_trigger for a descriptions of the +params+ hash.

--- a/lib/rubyrep/table_spec_resolver.rb
+++ b/lib/rubyrep/table_spec_resolver.rb
@@ -88,7 +88,7 @@ module RR
         case table_spec
         when /^\/.*\/$/ # matches e. g. '/^user/'
           table_spec = table_spec.sub(/^\/(.*)\/$/,'\1') # remove leading and trailing slash
-          matching_tables = tables(:left).grep(Regexp.new(table_spec, Regexp::IGNORECASE, 'U'))
+          matching_tables = tables(:left).grep(Regexp.new(table_spec, Regexp::IGNORECASE))
           matching_tables.each do |table|
             if !verify or tables(:right).include? table
               table_pairs << {:left => table, :right => table}

--- a/spec/db_specific_connection_extenders_spec.rb
+++ b/spec/db_specific_connection_extenders_spec.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 include RR
 
-extenders = [:mysql, :postgres]
+extenders = [:mysql2, :postgres]
 
 extenders.each do |extender|
   describe "#{extender.to_s.capitalize} Connection Extender" do

--- a/spec/db_specific_replication_extenders_spec.rb
+++ b/spec/db_specific_replication_extenders_spec.rb
@@ -6,7 +6,7 @@ require 'postgresql_replication_spec.rb'
 
 include RR
 
-extenders = [:postgres, :mysql]
+extenders = [:postgres, :mysql2]
 
 extenders.each do |extender|
   describe "#{extender.to_s.capitalize} Replication Extender" do

--- a/tasks/database.rake
+++ b/tasks/database.rake
@@ -14,7 +14,7 @@ def create_database(config)
     case config[:adapter]
     when 'postgresql'
       `createdb "#{config[:database]}" -E utf8`
-    when 'mysql'
+    when 'mysql2'
       @charset   = ENV['CHARSET']   || 'utf8'
       @collation = ENV['COLLATION'] || 'utf8_general_ci'
       begin
@@ -38,7 +38,7 @@ def drop_database(config)
   case config[:adapter]
   when 'postgresql'
     `dropdb "#{config[:database]}"`
-  when 'mysql'
+  when 'mysql2'
     connection = RR::ConnectionExtenders.db_connect(config.merge({'database' => nil}))
     connection.drop_database config[:database]
   else

--- a/tasks/redmine_test.rake
+++ b/tasks/redmine_test.rake
@@ -15,7 +15,7 @@ def install_redmine(database, name = nil)
     ENV['RAILS_ENV'] = 'production'
     config = File.read('config/database.yml.example')
     config.gsub! 'redmine', name
-    config.gsub! 'mysql', database
+    config.gsub! 'mysql2', database
     if database == 'postgresql'
       config.gsub! 'root', 'postgres'
     end

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -40,7 +40,7 @@ namespace :spec do
   
   desc "Run the specs for all supported databases"
   task :all_dbs do
-    [:postgres, :mysql].each do |test_db|
+    [:postgres, :mysql2].each do |test_db|
       puts "Running specs for #{test_db}"
       system "bash -c 'RR_TEST_DB=#{test_db} spec spec'"
     end
@@ -48,7 +48,7 @@ namespace :spec do
   
   desc "Run the specs for all supported databases and ruby platforms" 
   task :all_rubies do
-    system %(rvm exec bash -c 'for db in postgres mysql; do echo "`rvm current` - $db:"; RR_TEST_DB=$db spec spec; done')
+    system %(rvm exec bash -c 'for db in postgres mysql2; do echo "`rvm current` - $db:"; RR_TEST_DB=$db spec spec; done')
   end
   
   begin


### PR DESCRIPTION
Now uses :mysql2 as a key everywhere.  This now works with the mysql2 gem in a Rails 3 application.
